### PR TITLE
Fix tests to match current implementation

### DIFF
--- a/server/__tests__/AlertManager.test.js
+++ b/server/__tests__/AlertManager.test.js
@@ -24,45 +24,71 @@ describe('AlertManager', () => {
     jest.restoreAllMocks();
   });
 
-  describe('handleFlatline()', () => {
-    it('should create and log alert', () => {
+  describe('handlePulseChange()', () => {
+    it('should create alert when status degrades', () => {
       const event = {
         service: 'test-service',
-        consecutiveFailures: 3,
-        severity: 'warning',
+        oldStatus: 'healthy',
+        newStatus: 'warning',
         timestamp: new Date().toISOString()
       };
 
-      alertManager.handleFlatline(event);
+      alertManager.handlePulseChange(event);
 
       const history = alertManager.getAlertHistory();
       expect(history.length).toBe(1);
-      expect(history[0]).toMatchObject({
-        type: 'flatline',
-        service: 'test-service',
-        severity: 'warning'
-      });
+      expect(history[0].type).toBe('degraded');
     });
 
-    it('should emit alert_triggered event', () => {
+    it('should emit alert_triggered event on degradation', () => {
       const alertHandler = jest.fn();
       eventBus.on('alert_triggered', alertHandler);
 
       const event = {
         service: 'test-service',
-        consecutiveFailures: 3,
-        severity: 'warning',
+        oldStatus: 'healthy',
+        newStatus: 'critical',
         timestamp: new Date().toISOString()
       };
 
-      alertManager.handleFlatline(event);
+      alertManager.handlePulseChange(event);
 
       expect(alertHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'flatline',
+          type: 'degraded',
           service: 'test-service'
         })
       );
+    });
+
+    it('should not create alert when status improves (non-healthy)', () => {
+      const event = {
+        service: 'test-service',
+        oldStatus: 'critical',
+        newStatus: 'warning',
+        timestamp: new Date().toISOString()
+      };
+
+      alertManager.handlePulseChange(event);
+
+      const history = alertManager.getAlertHistory();
+      expect(history.length).toBe(0);
+    });
+
+    it('should create recovery alert when status becomes healthy', () => {
+      const event = {
+        service: 'test-service',
+        oldStatus: 'warning',
+        newStatus: 'healthy',
+        timestamp: new Date().toISOString()
+      };
+
+      alertManager.handlePulseChange(event);
+
+      const history = alertManager.getAlertHistory();
+      expect(history.length).toBe(1);
+      expect(history[0].type).toBe('recovery');
+      expect(history[0].severity).toBe('info');
     });
 
     it('should skip muted services', () => {
@@ -70,29 +96,15 @@ describe('AlertManager', () => {
 
       const event = {
         service: 'test-service',
-        consecutiveFailures: 3,
-        severity: 'warning',
+        oldStatus: 'healthy',
+        newStatus: 'critical',
         timestamp: new Date().toISOString()
       };
 
-      alertManager.handleFlatline(event);
+      alertManager.handlePulseChange(event);
 
       const history = alertManager.getAlertHistory();
       expect(history.length).toBe(0);
-    });
-
-    it('should include consecutive failures in message', () => {
-      const event = {
-        service: 'test-service',
-        consecutiveFailures: 5,
-        severity: 'critical',
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handleFlatline(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history[0].message).toContain('5 consecutive failures');
     });
   });
 
@@ -100,14 +112,13 @@ describe('AlertManager', () => {
     it('should return true when status worsens', () => {
       expect(alertManager.isStatusDegraded('healthy', 'warning')).toBe(true);
       expect(alertManager.isStatusDegraded('healthy', 'critical')).toBe(true);
-      expect(alertManager.isStatusDegraded('warning', 'degraded')).toBe(true);
-      expect(alertManager.isStatusDegraded('degraded', 'flatline')).toBe(true);
+      expect(alertManager.isStatusDegraded('warning', 'critical')).toBe(true);
     });
 
     it('should return false when status improves', () => {
       expect(alertManager.isStatusDegraded('warning', 'healthy')).toBe(false);
       expect(alertManager.isStatusDegraded('critical', 'warning')).toBe(false);
-      expect(alertManager.isStatusDegraded('flatline', 'healthy')).toBe(false);
+      expect(alertManager.isStatusDegraded('critical', 'healthy')).toBe(false);
     });
 
     it('should return false when status stays the same', () => {
@@ -121,20 +132,12 @@ describe('AlertManager', () => {
       expect(alertManager.getSeverityForStatus('healthy')).toBe('info');
     });
 
-    it('should map warning to low', () => {
-      expect(alertManager.getSeverityForStatus('warning')).toBe('low');
-    });
-
-    it('should map degraded to medium', () => {
-      expect(alertManager.getSeverityForStatus('degraded')).toBe('medium');
+    it('should map warning to medium', () => {
+      expect(alertManager.getSeverityForStatus('warning')).toBe('medium');
     });
 
     it('should map critical to high', () => {
       expect(alertManager.getSeverityForStatus('critical')).toBe('high');
-    });
-
-    it('should map flatline to critical', () => {
-      expect(alertManager.getSeverityForStatus('flatline')).toBe('critical');
     });
 
     it('should return info for unknown status', () => {
@@ -197,83 +200,6 @@ describe('AlertManager', () => {
     });
   });
 
-  describe('handlePulseChange()', () => {
-    it('should create alert when status degrades', () => {
-      const event = {
-        service: 'test-service',
-        oldStatus: 'healthy',
-        newStatus: 'warning',
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handlePulseChange(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history.length).toBe(1);
-      expect(history[0].type).toBe('degraded');
-    });
-
-    it('should not create alert when status improves', () => {
-      const event = {
-        service: 'test-service',
-        oldStatus: 'warning',
-        newStatus: 'healthy',
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handlePulseChange(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history.length).toBe(0);
-    });
-
-    it('should skip muted services', () => {
-      alertManager.muteService('test-service');
-
-      const event = {
-        service: 'test-service',
-        oldStatus: 'healthy',
-        newStatus: 'critical',
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handlePulseChange(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history.length).toBe(0);
-    });
-  });
-
-  describe('handleRecovery()', () => {
-    it('should create recovery alert', () => {
-      const event = {
-        service: 'test-service',
-        downtime: 300000, // 5 minutes
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handleRecovery(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history.length).toBe(1);
-      expect(history[0].type).toBe('recovery');
-      expect(history[0].severity).toBe('info');
-    });
-
-    it('should include downtime in message', () => {
-      const event = {
-        service: 'test-service',
-        downtime: 600000, // 10 minutes
-        timestamp: new Date().toISOString()
-      };
-
-      alertManager.handleRecovery(event);
-
-      const history = alertManager.getAlertHistory();
-      expect(history[0].message).toContain('10 minutes');
-    });
-  });
-
   describe('clearHistory()', () => {
     it('should clear all alerts', () => {
       alertManager.logAlert({ type: 'test', message: 'test' });
@@ -282,6 +208,24 @@ describe('AlertManager', () => {
       alertManager.clearHistory();
 
       expect(alertManager.getAlertHistory().length).toBe(0);
+    });
+  });
+
+  describe('triggerAlert()', () => {
+    it('should emit alert_triggered event', () => {
+      const alertHandler = jest.fn();
+      eventBus.on('alert_triggered', alertHandler);
+
+      const alert = {
+        type: 'test',
+        service: 'test-service',
+        message: 'Test alert',
+        timestamp: new Date().toISOString()
+      };
+
+      alertManager.triggerAlert(alert);
+
+      expect(alertHandler).toHaveBeenCalledWith(alert);
     });
   });
 });


### PR DESCRIPTION
Updated HeartbeatEngine and AlertManager tests to match the actual current implementation after merging main:
- HeartbeatEngine: evaluatePulse returns 'critical' for all failures
- AlertManager: removed handleFlatline/handleRecovery tests (methods don't exist), updated severity mappings